### PR TITLE
Pipenv and pip version can be set through env var

### DIFF
--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -49,13 +49,18 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
             mcount "buildvar.SLUGIFY_USES_TEXT_UNIDECODE"
         fi
 
-        export PIPENV_VERSION="2018.5.18"
+        if [[ -r "$ENV_DIR/BUILD_PIPENV_VERSION" ]]; then
+            BUILD_PIPENV_VERSION="$(cat "$ENV_DIR/BUILD_PIPENV_VERSION")"
+        fi
+
+        export _PIPENV_VERSION="${BUILD_PIPENV_VERSION:-2018.5.18}"
+
 
         # Install pipenv.
         # Due to weird old pip behavior and pipenv behavior, pipenv upgrades pip
         # to latest if only --upgrade is specified. Specify upgrade strategy to
         # avoid this eager behavior.
-        /app/.heroku/python/bin/pip install pipenv==$PIPENV_VERSION --upgrade --upgrade-strategy only-if-needed &> /dev/null
+        /app/.heroku/python/bin/pip install pipenv==$_PIPENV_VERSION --upgrade --upgrade-strategy only-if-needed &> /dev/null
 
         # Install the test dependencies, for CI.
         if [ "$INSTALL_TEST" ]; then
@@ -64,7 +69,7 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
 
         # Install the dependencies.
         elif [[ ! -f Pipfile.lock ]]; then
-            puts-step "Installing dependencies with Pipenv $PIPENV_VERSION…"
+            puts-step "Installing dependencies with Pipenv $_PIPENV_VERSION…"
             /app/.heroku/python/bin/pipenv install --system --skip-lock 2>&1 | indent
 
         else
@@ -72,7 +77,7 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
             cp requirements.txt .heroku/python/requirements-declared.txt
             openssl dgst -sha256 Pipfile.lock > .heroku/python/Pipfile.lock.sha256
 
-            puts-step "Installing dependencies with Pipenv $PIPENV_VERSION…"
+            puts-step "Installing dependencies with Pipenv $_PIPENV_VERSION…"
             /app/.heroku/python/bin/pipenv install --system --deploy 2>&1 | indent
         fi
     fi

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -142,7 +142,11 @@ fi
 
 set -e
 
-PIP_VERSION='20.1.1'
+if [[ -r "$ENV_DIR/BUILD_PIP_VERSION" ]]; then
+  BUILD_PIP_VERSION="$(cat "$ENV_DIR/BUILD_PIP_VERSION")"
+fi
+PIP_VERSION="${BUILD_PIP_VERSION:-20.1.1}"
+
 # Must use setuptools <47.2.0 until we fix:
 # https://github.com/heroku/heroku-buildpack-python/issues/1006
 SETUPTOOLS_VERSION='47.1.1'
@@ -176,10 +180,6 @@ if ! curl -sSf "${PIP_WHEEL_URL}" -o "$PIP_WHEEL"; then
 fi
 
 if [[ -f "$BUILD_DIR/Pipfile" ]]; then
-  # The buildpack is pinned to old pipenv, which requires older pip.
-  # Pip 9.0.2 doesn't support installing itself from a wheel, so we have to use split
-  # versions here (ie: installer pip version different from target pip version).
-  PIP_VERSION='9.0.2'
   PIP_TO_INSTALL="pip==${PIP_VERSION}"
 else
   PIP_TO_INSTALL="${PIP_WHEEL}"


### PR DESCRIPTION
Add the ability to override PIP_VERSION & PIPENV_VERSION
I deployed a review app using it (and successfully added `ddtrace`) — [there](https://dashboard.heroku.com/apps/fr-api-enh-ddtrace-8oxqtfnjdnq/activity/releases/e1f5d548-3c77-4974-b883-15c46d0f1e41)

# how 

- `PIPENV_VERSION` can not be used as env var see [there](https://github.com/pypa/pipenv/issues/3633)
- Heroku configuration variables are available in files see [there](https://devcenter.heroku.com/articles/buildpack-api#bin-compile-summary)